### PR TITLE
Package and CI maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,15 @@ dart:
   - "2.4.1"
   - "2.5.1"
   - "2.6.1"
+  - "2.7.2"
   - stable
   - dev
 
-matrix:
+jobs:
   allow_failures:
+    - dart: 2.6.1
     - dart: dev
+  fast_finish: true
 
 dart_task:
   - test

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,18 +1,19 @@
 # https://www.dartlang.org/guides/language/analysis-options
 # Use Google internal analysis options from
 # https://pub.dartlang.org/packages/pedantic
-import: package:pedantic/analysis_options.yaml
+include: package:pedantic/analysis_options.yaml
 
 analyzer:
   strong-mode:
     implicit-casts: true
     implicit-dynamic: false
 
-# Source of linter options:
+# Linter rules customisations. Source of linter options:
 # http://dart-lang.github.io/linter/lints/options/options.html
 linter:
   rules:
-    - control_flow_in_finally
-    - empty_statements
-    - throw_in_finally
-    - unnecessary_new
+    control_flow_in_finally: true
+    empty_statements: true
+    throw_in_finally: true
+    unnecessary_this: false
+    omit_local_variable_types: false


### PR DESCRIPTION
* Correctly configure pedantic analyzer_options include
* Ignore failing tests on Dart SDK 2.6 due to issue in newest analyzer package (see dart-lang/sdk#42888)
* Additionally test on Dart SDK 2.7