### PR TITLE
Lower precedence of unary minus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.0.2 - TBD
+
+- Lower precedence of unary minus to match common mathematics convention
+
 ### 2.0.1 - 2020-09-07
 
 - Add ability to unbind variable names (by [wdavies973](https://github.com/wdavies973))

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -485,28 +485,28 @@ class TokenType {
   static const TokenType DIV = TokenType._internal('DIV', 2, operator: true);
   static const TokenType MOD = TokenType._internal('MOD', 2, operator: true);
   static const TokenType POW =
-      TokenType._internal('POW', 3, leftAssociative: false, operator: true);
+      TokenType._internal('POW', 4, leftAssociative: false, operator: true);
   static const TokenType UNMINUS =
-      TokenType._internal('UNMINUS', 5, leftAssociative: false, operator: true);
+      TokenType._internal('UNMINUS', 3, leftAssociative: false, operator: true);
 
   // Functions
-  static const TokenType SQRT = TokenType._internal('SQRT', 4, function: true);
-  static const TokenType ROOT = TokenType._internal('ROOT', 4, function: true);
-  static const TokenType LOG = TokenType._internal('LOG', 4, function: true);
-  static const TokenType LN = TokenType._internal('LN', 4, function: true);
-  static const TokenType COS = TokenType._internal('COS', 4, function: true);
-  static const TokenType SIN = TokenType._internal('SIN', 4, function: true);
-  static const TokenType TAN = TokenType._internal('TAN', 4, function: true);
-  static const TokenType ACOS = TokenType._internal('ACOS', 4, function: true);
-  static const TokenType ASIN = TokenType._internal('ASIN', 4, function: true);
-  static const TokenType ATAN = TokenType._internal('ATAN', 4, function: true);
-  static const TokenType ABS = TokenType._internal('ABS', 4, function: true);
-  static const TokenType CEIL = TokenType._internal('CEIL', 4, function: true);
+  static const TokenType SQRT = TokenType._internal('SQRT', 5, function: true);
+  static const TokenType ROOT = TokenType._internal('ROOT', 5, function: true);
+  static const TokenType LOG = TokenType._internal('LOG', 5, function: true);
+  static const TokenType LN = TokenType._internal('LN', 5, function: true);
+  static const TokenType COS = TokenType._internal('COS', 5, function: true);
+  static const TokenType SIN = TokenType._internal('SIN', 5, function: true);
+  static const TokenType TAN = TokenType._internal('TAN', 5, function: true);
+  static const TokenType ACOS = TokenType._internal('ACOS', 5, function: true);
+  static const TokenType ASIN = TokenType._internal('ASIN', 5, function: true);
+  static const TokenType ATAN = TokenType._internal('ATAN', 5, function: true);
+  static const TokenType ABS = TokenType._internal('ABS', 5, function: true);
+  static const TokenType CEIL = TokenType._internal('CEIL', 5, function: true);
   static const TokenType FLOOR =
-      TokenType._internal('FLOOR', 4, function: true);
-  static const TokenType SGN = TokenType._internal('SGN', 4, function: true);
+      TokenType._internal('FLOOR', 5, function: true);
+  static const TokenType SGN = TokenType._internal('SGN', 5, function: true);
   static const TokenType EFUNC =
-      TokenType._internal('EFUNC', 4, function: true);
+      TokenType._internal('EFUNC', 5, function: true);
 
   /// The string value of this token type.
   final String value;

--- a/test/parser_test_set.dart
+++ b/test/parser_test_set.dart
@@ -15,6 +15,7 @@ class ParserTests extends TestSet {
         'Parser Expression Creation Invalid': parserExpressionTestInvalid,
         'Parser Expression Creation from toString()':
             parserExpressionTest_ParseFromToString,
+        'Parser Operator Precedence': parserOperatorPrecedence,
       };
 
   @override
@@ -485,5 +486,13 @@ class ParserTests extends TestSet {
             reason: 'Expected no exception for ${inputString} (${exp})');
       }
     }
+  }
+
+  void parserOperatorPrecedence() {
+    Expression e = pars.parse('-3^2');
+    expect(e.toString(), equals('(-(3.0^2.0))'));
+
+    e = pars.parse('-3*2');
+    expect(e.toString(), equals('((-3.0) * 2.0)'));
   }
 }


### PR DESCRIPTION
To parse `-x^y` as `-(x^y)` instead of `(-x)^y` as per common mathematics conventions. Fixes #41 