### PR TITLE
Fix inaccuracies in sin/cos/tan when using math.pi (machine pi)

### DIFF
--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -588,6 +588,11 @@ class Sin extends DefaultFunction {
     final dynamic argEval = arg.evaluate(type, context);
 
     if (type == EvaluationType.REAL) {
+      // Compensate for inaccuracies in machine-pi.
+      // If argEval divides cleanly from pi, return 0.
+      if ((argEval / math.pi).abs() % 1 == 0) {
+        return 0;
+      }
       return math.sin(argEval);
     }
 
@@ -634,6 +639,12 @@ class Cos extends DefaultFunction {
     final dynamic argEval = arg.evaluate(type, context);
 
     if (type == EvaluationType.REAL) {
+      // Compensate for inaccuracies in machine-pi.
+      //
+      // If argEval divides cleanly from pi (when shifted back to Sin from Cos), return 0.
+      if (((argEval - math.pi / 2) / math.pi).abs() % 1 == 0) {
+        return 0;
+      }
       return math.cos(argEval);
     }
 
@@ -680,6 +691,11 @@ class Tan extends DefaultFunction {
     final dynamic argEval = arg.evaluate(type, context);
 
     if (type == EvaluationType.REAL) {
+      // Compensate for inaccuracies in machine-pi.
+      // If argEval divides cleanly from pi, return 0.
+      if ((argEval / math.pi).abs() % 1 == 0) {
+        return 0;
+      }
       return math.tan(argEval);
     }
 

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -591,7 +591,7 @@ class Sin extends DefaultFunction {
       // Compensate for inaccuracies in machine-pi.
       // If argEval divides cleanly from pi, return 0.
       if ((argEval / math.pi).abs() % 1 == 0) {
-        return 0;
+        return 0.0;
       }
       return math.sin(argEval);
     }
@@ -643,7 +643,7 @@ class Cos extends DefaultFunction {
       //
       // If argEval divides cleanly from pi (when shifted back to Sin from Cos), return 0.
       if (((argEval - math.pi / 2) / math.pi).abs() % 1 == 0) {
-        return 0;
+        return 0.0;
       }
       return math.cos(argEval);
     }
@@ -694,7 +694,7 @@ class Tan extends DefaultFunction {
       // Compensate for inaccuracies in machine-pi.
       // If argEval divides cleanly from pi, return 0.
       if ((argEval / math.pi).abs() % 1 == 0) {
-        return 0;
+        return 0.0;
       }
       return math.tan(argEval);
     }


### PR DESCRIPTION
# Description

Since `math.pi` is only an approximation, things like `Sin(pi)` with `pi` bound to `math.pi` will return a really small number, which is correct behavior.

However, this doesn't really make sense from an end-user perspective. We can manually check for multiples of Pi and return 0.

This is the behavior of [Arity](https://github.com/hoijui/arity), which was previously used for the Android Calculator.