### PR TITLE
Update `pub run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ math_expressions is inspired by [mathExpr][] for Java and distributed under the
 This package contains a very simple [command-line interpreter](bin/interpreter.dart)
 for real numbers:
 
-    flutter pub run math_expressions:interpreter
+    dart pub run math_expressions:interpreter
 
 ### What's not working yet?
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ math_expressions is inspired by [mathExpr][] for Java and distributed under the
 This package contains a very simple [command-line interpreter](bin/interpreter.dart)
 for real numbers:
 
-    pub run math_expressions:interpreter
+    flutter pub run math_expressions:interpreter
 
 ### What's not working yet?
 


### PR DESCRIPTION
The dart pub command debuted in Dart 2.10. Although you might still find examples of using the standalone pub command instead of dart pub or flutter pub, the standalone pub command is deprecated.