### PR TITLE
Evaluate roots written as fraction powers if base is negative 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2.3.1- 2022-03-21
+
+- Evaluate roots written as powers correctly for negative bases.
+
 ## [2.3.0] - 2021-12-21
 
 ### Added

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: math_expressions
-version: 2.3.0
+version: 2.3.1
 homepage: https://github.com/fkleon/math-expressions
 description: A library for parsing and evaluating mathematical expressions, supporting real numbers, vectors, and basic interval arithmetic.
 

--- a/test/expression_test_set.dart
+++ b/test/expression_test_set.dart
@@ -39,8 +39,8 @@ class ExpressionTests extends TestSet {
         /*
         'Composite Function simplification': compFuncSimplification,
         'Composite Function differentiation': compFuncDifferentiation,
-        'Composite Function evaluation': compFunEval
-        */
+         */
+        'Composite Function evaluation': compFunEval,
         'Algorithmic Function creation': algorithmicFunctionCreation,
         'Algorithmic Function evaluation [REAL]': algorithmicFunctionRealEval,
       };
@@ -1308,8 +1308,19 @@ class ExpressionTests extends TestSet {
 
   /// Tests evaluation of composite functions.
   void compFunEval() {
-    // Evaluate composite functions.
-    throw UnimplementedError();
+    // See https://github.com/fkleon/math-expressions/pull/66#issue-1175180681
+    final x = Variable('x');
+    final one = Number(1), two = Number(2), three = Number(2);
+    final f = Power(x, Divide(two, three));
+    final g = Power(Power(x, two), Divide(one, three));
+
+    final contextModel = ContextModel()..bindVariable(x, Number(-1));
+
+    final double result1 = f.evaluate(EvaluationType.REAL, contextModel);
+    final double result2 = g.evaluate(EvaluationType.REAL, contextModel);
+
+    expect(result1, closeTo(1, EPS));
+    expect(result2, closeTo(1, EPS));
   }
 
   /// Tests creation of algorithmic functions.

--- a/test/expression_test_set.dart
+++ b/test/expression_test_set.dart
@@ -39,7 +39,7 @@ class ExpressionTests extends TestSet {
         /*
         'Composite Function simplification': compFuncSimplification,
         'Composite Function differentiation': compFuncDifferentiation,
-         */
+        */
         'Composite Function evaluation': compFunEval,
         'Algorithmic Function creation': algorithmicFunctionCreation,
         'Algorithmic Function evaluation [REAL]': algorithmicFunctionRealEval,


### PR DESCRIPTION
The following equations are equal:
<img src="https://render.githubusercontent.com/render/math?math=f(x) = x^{\frac{2}{3}}, g(x) = \sqrt[3]{x^2}">

However, evaluating those for a negative `x` wont raise the same result. This is due to the IEEE standard for floating point arithmetic, which defines `NaN` for the case of a negative base and a non-integer exponent. Since this package is not about floating point arithmetic, but rather about mathematical equations, I would like to propose a fix for at least that case.

The following test succeeds with the proposed change.

```dart
test('root equivalence', () {
    final f = Parser().parse('(x^(2.0 / 3.0))');
    final g = Parser().parse('((x^2.0)^(1.0 / 3.0))');

    final contextModel = ContextModel()..bindVariable(Variable('x'), Number(-1));

    final result1 = f.evaluate(EvaluationType.REAL, contextModel);
    final result2 = g.evaluate(EvaluationType.REAL, contextModel);

    expect((result1 - result2) < 1e-10, true);
  });
```