### PR TITLE
[README.md] use markdown latex instead of images

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,10 @@ Below are two basic examples of how to use this library. There also is some [add
 
 This example shows how to evaluate
 
-$$
-frac{(x^2+\cos y)}{3}
-$$
+$\frac{(x^2+\cos y)}{3}$
 
 
-$$
-\text{for } x=2, y=\pi
-$$
+for $x=2, y=\pi$
 
 #### Build the expression
 
@@ -85,9 +81,7 @@ You can either create an mathematical expression programmatically or parse a str
 
 This example shows how to simplify and differentiate
 
-$$
-x \cdot 1 - (-5)
-$$
+$x \cdot 1 - (-5)$
 
 * Expressions can be simplified and differentiated with respect to a given variable:
 ```dart

--- a/README.md
+++ b/README.md
@@ -116,6 +116,3 @@ supporting interval arithmetics.
 [function_tree]: https://pub.dartlang.org/packages/function_tree "A library for parsing and evaluating numerical functions built from strings."
 [dartdoc]: https://pub.dartlang.org/documentation/math_expressions/latest/
 [defaultFunctions]: https://pub.dartlang.org/documentation/math_expressions/latest/math_expressions/DefaultFunction-class.html
-[exampleEq1]: https://latex.codecogs.com/gif.latex?%28x%5E2%2Bcos%28y%29%29%2F3
-[exampleEq1xy]: https://latex.codecogs.com/gif.latex?x%3D2%2Cy%3D%5Cpi
-[exampleEq2]: https://latex.codecogs.com/gif.latex?x*1-%28-5%29

--- a/README.md
+++ b/README.md
@@ -38,10 +38,14 @@ Below are two basic examples of how to use this library. There also is some [add
 
 This example shows how to evaluate
 
-![Equation 1][exampleEq1]
+$$
+frac{(x^2+\cos y)}{3}
+$$
 
-for
-![xy][exampleEq1xy]
+
+$$
+\text{for } x=2, y=\pi
+$$
 
 #### Build the expression
 
@@ -81,7 +85,9 @@ You can either create an mathematical expression programmatically or parse a str
 
 This example shows how to simplify and differentiate
 
-![Example 2][exampleEq2]
+$$
+x \cdot 1 - (-5)
+$$
 
 * Expressions can be simplified and differentiated with respect to a given variable:
 ```dart


### PR DESCRIPTION
With dark mode, the README.md looks like this:
![image](https://user-images.githubusercontent.com/43615701/229906597-7af91821-00c0-4a8c-8766-f0172413ba99.png)

I am offering to use [Github's native markdown feature](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions) that allows to render LaTeX.

Feel free to ask for more tweaking, or to just close this PR and create another that better suites your preferances.