### PR TITLE
Switch from pedantic to the official Dart lint rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Switch from pedantic to the [official Dart lint rules](https://pub.dev/packages/lints)
+
 ## [2.4.0] - 2023-04-05
 
 ### Added

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,7 @@
-# https://www.dartlang.org/guides/language/analysis-options
-# Use Google internal analysis options from
-# https://pub.dartlang.org/packages/pedantic
-include: package:pedantic/analysis_options.yaml
+# https://dart.dev/tools/analysis#the-analysis-options-file
+# Use official Dart lint rules from
+# https://pub.dev/documentation/lints/latest/#recommended-lints
+include: package:lints/recommended.yaml
 
 analyzer:
   language:
@@ -15,6 +15,5 @@ linter:
   rules:
     control_flow_in_finally: true
     empty_statements: true
-    throw_in_finally: true
     unnecessary_this: false
-    omit_local_variable_types: false
+    constant_identifier_names: false

--- a/lib/src/expression.dart
+++ b/lib/src/expression.dart
@@ -872,7 +872,7 @@ class Variable extends Literal {
   Expression derive(String toVar) => name == toVar ? Number(1.0) : Number(0.0);
 
   @override
-  String toString() => '$name';
+  String toString() => name;
 
   @override
   dynamic evaluate(EvaluationType type, ContextModel context) =>

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -93,7 +93,7 @@ class CompositeFunction extends MathFunction {
     MathFunction gDF;
     final Expression gD = g.derive(toVar);
 
-    if (!(gD is MathFunction)) {
+    if ((gD is! MathFunction)) {
       // Build function again..
       gDF = CustomFunction('d${g.name}', g.args, gD);
     } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   vector_math: ^2.1.0
 
 dev_dependencies:
-  pedantic: ^1.11.0
+  lints: ^2.1.1
   test: ^1.16.7
 
 environment:

--- a/test/expression_test_set.dart
+++ b/test/expression_test_set.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unused_local_variable
+
 part of math_expressions_test;
 
 /// Contains methods to test the math expression implementation.


### PR DESCRIPTION
The pedantic rule set was deprecated a while ago, and it's now recommended to use the official Dart lint rules instead.