### PR TITLE
Update to lints 3.0.0

### DIFF
--- a/lib/src/algebra.dart
+++ b/lib/src/algebra.dart
@@ -31,7 +31,7 @@ class Point3 extends Vector3 {
   /// Checks for equality. Two points are considered equal, if their coordinates
   /// match.
   @override
-  bool operator ==(Object? o) {
+  bool operator ==(Object o) {
     if (o is Point3) {
       return this.x == o.x && this.y == o.y && this.z == o.z;
     } else {

--- a/lib/src/algebra.dart
+++ b/lib/src/algebra.dart
@@ -1,4 +1,4 @@
-part of math_expressions;
+part of '../math_expressions.dart';
 
 /// A point in 3-dimensional space, which is a Vector3.
 /// This implementation supplies common mathematical operations on points.

--- a/lib/src/evaluator.dart
+++ b/lib/src/evaluator.dart
@@ -1,4 +1,4 @@
-part of math_expressions;
+part of '../math_expressions.dart';
 
 /// Mathematical expressions must be evaluated under a certain [EvaluationType].
 ///

--- a/lib/src/expression.dart
+++ b/lib/src/expression.dart
@@ -1,4 +1,4 @@
-part of math_expressions;
+part of '../math_expressions.dart';
 
 /// Any Expression supports basic mathematical operations like
 /// addition, subtraction, multiplication, division, power and negate.

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -1,4 +1,4 @@
-part of math_expressions;
+part of '../math_expressions.dart';
 
 /// A function with an arbitrary number of arguments.
 ///

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1,4 +1,4 @@
-part of math_expressions;
+part of '../math_expressions.dart';
 
 /// The Parser creates a mathematical [Expression] from a given input string.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   vector_math: ^2.1.0
 
 dev_dependencies:
-  lints: ^2.1.1
+  lints: ^3.0.0
   test: ^1.16.7
 
 environment:

--- a/test/algebra_test_set.dart
+++ b/test/algebra_test_set.dart
@@ -1,4 +1,4 @@
-part of math_expressions_test;
+part of 'math_expressions_test.dart';
 
 /// Contains methods to test the math algebra implementation.
 class AlgebraTests extends TestSet {

--- a/test/expression_test_set.dart
+++ b/test/expression_test_set.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: unused_local_variable
-
-part of math_expressions_test;
+part of 'math_expressions_test.dart';
 
 /// Contains methods to test the math expression implementation.
 class ExpressionTests extends TestSet {

--- a/test/parser_test_set.dart
+++ b/test/parser_test_set.dart
@@ -1,4 +1,4 @@
-part of math_expressions_test;
+part of 'math_expressions_test.dart';
 
 /// Contains a test set for testing the parser and lexer
 class ParserTests extends TestSet {


### PR DESCRIPTION
* Update `lints` to 3.0.0
* Fix a few linting errors related to `use_string_in_part_of_directives`.
* Fix lint error `non_nullable_equals_parameter` in upcoming Dart version.
