### PR TITLE
Refactor and clean up test suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Drop support for Dart SDK versions below 3.0.0
 - Switch from pedantic to the [official Dart lint rules](https://pub.dev/packages/lints)
 
 ## [2.4.0] - 2023-04-05

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,4 +1,6 @@
 tags:
   algebra:
+  lexer:
   parser:
+  petitparser:
   expression:

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,4 @@
+tags:
+  algebra:
+  parser:
+  expression:

--- a/lib/src/expression.dart
+++ b/lib/src/expression.dart
@@ -159,7 +159,7 @@ class UnaryMinus extends UnaryOperator {
   /// or just:
   ///
   ///     minus_one = UnaryMinus(1);
-  UnaryMinus(dynamic exp) : super(exp);
+  UnaryMinus(super.exp);
 
   @override
   Expression derive(String toVar) => UnaryMinus(exp.derive(toVar));
@@ -205,7 +205,7 @@ class UnaryPlus extends UnaryOperator {
   /// or just:
   ///
   ///     plus_one = UnaryPlus(1);
-  UnaryPlus(dynamic exp) : super(exp);
+  UnaryPlus(super.exp);
 
   @override
   Expression derive(String toVar) => UnaryPlus(exp.derive(toVar));
@@ -235,7 +235,7 @@ class Plus extends BinaryOperator {
   /// or:
   ///
   ///     addition = Variable('x') + Number(4);
-  Plus(dynamic first, dynamic second) : super(first, second);
+  Plus(super.first, super.second);
 
   @override
   Expression derive(String toVar) =>
@@ -287,7 +287,7 @@ class Minus extends BinaryOperator {
   /// or:
   ///
   ///     subtraction = Number(5) - Variable('x');
-  Minus(dynamic first, dynamic second) : super(first, second);
+  Minus(super.first, super.second);
 
   @override
   Expression derive(String toVar) =>
@@ -339,7 +339,7 @@ class Times extends BinaryOperator {
   /// or:
   ///
   ///     product = Number(7) * Variable('x');
-  Times(dynamic first, dynamic second) : super(first, second);
+  Times(super.first, super.second);
 
   @override
   Expression derive(String toVar) => Plus(
@@ -430,7 +430,7 @@ class Divide extends BinaryOperator {
   /// or:
   ///
   ///     div = Variable('x') / (Variable('y') + Number(2));
-  Divide(dynamic dividend, dynamic divisor) : super(dividend, divisor);
+  Divide(super.dividend, super.divisor);
 
   @override
   Expression derive(String toVar) =>
@@ -512,7 +512,7 @@ class Modulo extends BinaryOperator {
   /// or:
   ///
   ///     r = Variable('x') % (Variable('y') + Number(2));
-  Modulo(dynamic dividend, dynamic divisor) : super(dividend, divisor);
+  Modulo(super.dividend, super.divisor);
 
   @override
   Expression derive(String toVar) {
@@ -567,7 +567,7 @@ class Power extends BinaryOperator {
   /// or:
   ///
   ///     pow = Variable('x') ^ Number(3.0);
-  Power(dynamic x, dynamic exp) : super(x, exp);
+  Power(super.x, super.exp);
 
   @override
   Expression derive(String toVar) => this.asE().derive(toVar);
@@ -767,7 +767,7 @@ class Vector extends Literal {
   ///
   ///     x = y = z = Number(1);
   ///     vec3 = Vector([x, y, z]);
-  Vector(List<Expression> elements) : super(elements);
+  Vector(List<Expression> super.elements);
 
   /// Convenience operator to access vector elements.
   Expression operator [](int i) => elements[i];

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -195,8 +195,7 @@ class CustomFunction extends MathFunction {
   ///
   /// The name of the function has no functional impact, and is only used in the
   /// string representation.
-  CustomFunction(String name, List<Variable> args, this.expression)
-      : super(name, args);
+  CustomFunction(super.name, super.args, this.expression);
 
   @override
   Expression derive(String toVar) =>
@@ -235,7 +234,7 @@ abstract class DefaultFunction extends MathFunction {
   /// __Note__:
   /// Must only be used internally for pre-defined functions, as it does not
   /// contain any expression. The Evaluator needs to know how to handle this.
-  DefaultFunction._unary(String name, Expression arg) : super._empty(name) {
+  DefaultFunction._unary(super.name, Expression arg) : super._empty() {
     final Variable bindingVariable = _wrapIntoVariable(arg);
     this.args = <Variable>[bindingVariable];
   }
@@ -247,8 +246,8 @@ abstract class DefaultFunction extends MathFunction {
   /// __Note__:
   /// Must only be used internally for pre-defined functions, as it does not
   /// contain any expression. The Evaluator needs to know how to handle this.
-  DefaultFunction._binary(String name, Expression arg1, Expression arg2)
-      : super._empty(name) {
+  DefaultFunction._binary(super.name, Expression arg1, Expression arg2)
+      : super._empty() {
     final Variable bindingVariable1 = _wrapIntoVariable(arg1);
     final Variable bindingVariable2 = _wrapIntoVariable(arg2);
     this.args = <Variable>[bindingVariable1, bindingVariable2];
@@ -257,8 +256,7 @@ abstract class DefaultFunction extends MathFunction {
   /// Creates a new function with given name and any arguments.
   /// If the arguments are not variables, they will be wrapped into anonymous
   /// variables, which bind the given expressions.
-  DefaultFunction._any(String name, List<Expression> args)
-      : super._empty(name) {
+  DefaultFunction._any(super.name, List<Expression> args) : super._empty() {
     this.args = args.map((arg) => _wrapIntoVariable(arg)).toList();
   }
 
@@ -407,7 +405,7 @@ class Ln extends Log {
   ///     ln = Ln(num10);
   ///
   /// To create a logarithm with arbitrary base, see [Log].
-  Ln(Expression arg) : super._ln(arg);
+  Ln(super.arg) : super._ln();
 
   @override
   Expression derive(String toVar) => arg.derive(toVar) / arg;
@@ -507,7 +505,7 @@ class Sqrt extends Root {
   /// For example, to create the square root of x:
   ///
   ///     sqrt = Sqrt(Variable('x'));
-  Sqrt(Expression arg) : super.sqrt(arg);
+  Sqrt(super.arg) : super.sqrt();
 
   /// Possible simplifications:
   ///
@@ -1011,8 +1009,7 @@ class AlgorithmicFunction extends DefaultFunction {
   /// The name of the function has no functional impact, and is only used in the
   /// string representation. If the function is defined via the Parser#addFunction
   /// method instead it is supported by the parser.
-  AlgorithmicFunction(String name, List<Expression> args, this.handler)
-      : super._any(name, args);
+  AlgorithmicFunction(super.name, super.args, this.handler) : super._any();
 
   Function handler;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,4 +11,4 @@ dev_dependencies:
   test: ^1.16.7
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ^3.0.0

--- a/test/algebra_test_set.dart
+++ b/test/algebra_test_set.dart
@@ -6,6 +6,9 @@ class AlgebraTests extends TestSet {
   String get name => 'Algebra Tests';
 
   @override
+  String get tags => 'algebra';
+
+  @override
   Map<String, Function> get testFunctions => {
         'Point Creation': pointCreation,
         'Point Equality': pointEquality,

--- a/test/expression_test_set.dart
+++ b/test/expression_test_set.dart
@@ -7,6 +7,9 @@ class ExpressionTests extends TestSet {
   String get name => 'Expression Tests';
 
   @override
+  String get tags => 'expression';
+
+  @override
   Map<String, Function> get testFunctions => {
         'Expression creation [REAL]': simpleRealCreation,
         'Expression creation [INTERVAL]': simpleIntervalCreation,

--- a/test/lexer_test_set.dart
+++ b/test/lexer_test_set.dart
@@ -1,0 +1,568 @@
+part of 'math_expressions_test.dart';
+
+/// Contains a test set for testing the lexer
+class LexerTests extends TestSet {
+  @override
+  String get name => 'Lexer Tests';
+
+  @override
+  String get tags => 'lexer';
+
+  @override
+  Map<String, Function> get testGroups => {
+        // Literals
+        'Value': tokenizeValue,
+        'Variable': tokenizeVariable,
+        'Parenthesis': tokenizeParenthesis,
+
+        // Operators
+        'Unary Minus': tokenizeUnaryMinus,
+        'Unary Plus': tokenizeUnaryPlus,
+        'Power': tokenizePower,
+        'Modulo': tokenizeModulo,
+        'Multiplication': tokenizeMultiplication,
+        'Division': tokenizeDivision,
+        'Plus': tokenizePlus,
+        'Minus': tokenizeMinus,
+
+        // Functions
+        'Functions': tokenizeFunctions,
+        'Algorithmic functions': tokenizeAlgorithmicFunctions,
+
+        // Expressions
+        'Complex expression': tokenizeComplexExpression,
+
+        // Negative test cases
+        'Invalid': lexerTokenTestInvalid,
+      };
+
+  @override
+  void initTests() {}
+
+  Lexer lex = Lexer();
+
+  // Test RPN
+  void parameterizedRpn(Map<String, List<Token>> cases) {
+    cases.forEach((expression, rpn) {
+      test('$expression -> $rpn',
+          () => expect(lex.tokenizeToRPN(expression), orderedEquals(rpn)));
+    });
+  }
+
+  /// Test infix and RPN
+  void parameterized(Map<String, (List<Token>, List<Token>)> cases) {
+    cases.forEach((expression, value) {
+      var (infix, rpn) = value;
+      test('$expression -> $infix -> $rpn', () {
+        var infixStream = lex.tokenize(expression);
+        expect(infixStream, orderedEquals(infix));
+        var rpnStream = lex.shuntingYard(infixStream);
+        expect(rpnStream, orderedEquals(rpn));
+      });
+    });
+  }
+
+  void tokenizeValue() {
+    var cases = {
+      '0': [Token('0', TokenType.VAL)],
+      '1': [Token('1', TokenType.VAL)],
+      '0.0': [Token('0.0', TokenType.VAL)],
+      '1.0': [Token('1.0', TokenType.VAL)],
+      math.pi.toStringAsFixed(11): [Token('3.14159265359', TokenType.VAL)],
+    };
+
+    parameterizedRpn(cases);
+  }
+
+  void tokenizeVariable() {
+    var cases = {
+      'x': [Token('x', TokenType.VAR)],
+      ' x': [Token('x', TokenType.VAR)],
+      'y': [Token('y', TokenType.VAR)],
+      '(y )': [Token('y', TokenType.VAR)],
+      //'var2': [Token('var2', TokenType.VAR)], // Does not support numbers in variable names
+      'longname': [Token('longname', TokenType.VAR)],
+    };
+    parameterizedRpn(cases);
+  }
+
+  void tokenizeUnaryMinus() {
+    var cases = {
+      '-0': (
+        [Token('-', TokenType.MINUS), Token('0', TokenType.VAL)],
+        [Token('0', TokenType.VAL), Token('-', TokenType.UNMINUS)]
+      ),
+      '-1.0': (
+        [Token('-', TokenType.MINUS), Token('1.0', TokenType.VAL)],
+        [Token('1.0', TokenType.VAL), Token('-', TokenType.UNMINUS)]
+      ),
+      '(-1)': (
+        [
+          Token('(', TokenType.LBRACE),
+          Token('-', TokenType.MINUS),
+          Token('1', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('1', TokenType.VAL), Token('-', TokenType.UNMINUS)]
+      ),
+      '-(1)': (
+        [
+          Token('-', TokenType.MINUS),
+          Token('(', TokenType.LBRACE),
+          Token('1', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('1', TokenType.VAL), Token('-', TokenType.UNMINUS)]
+      ),
+    };
+    parameterized(cases);
+  }
+
+  void tokenizeUnaryPlus() {
+    var cases = {
+      '+1': (
+        [Token('+', TokenType.PLUS), Token('1', TokenType.VAL)],
+        [Token('1', TokenType.VAL), Token('+', TokenType.UNPLUS)]
+      ),
+      '(+1)': (
+        [
+          Token('(', TokenType.LBRACE),
+          Token('+', TokenType.PLUS),
+          Token('1', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('1', TokenType.VAL), Token('+', TokenType.UNPLUS)]
+      ),
+      '+(1)': (
+        [
+          Token('+', TokenType.PLUS),
+          Token('(', TokenType.LBRACE),
+          Token('1', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('1', TokenType.VAL), Token('+', TokenType.UNPLUS)]
+      ),
+    };
+    parameterized(cases);
+  }
+
+  void tokenizePower() {
+    var cases = {
+      '1^1': (
+        [
+          Token('1', TokenType.VAL),
+          Token('^', TokenType.POW),
+          Token('1', TokenType.VAL)
+        ],
+        [
+          Token('1', TokenType.VAL),
+          Token('1', TokenType.VAL),
+          Token('^', TokenType.POW),
+        ]
+      ),
+      '1^1^1': (
+        [
+          Token('1', TokenType.VAL),
+          Token('^', TokenType.POW),
+          Token('1', TokenType.VAL),
+          Token('^', TokenType.POW),
+          Token('1', TokenType.VAL)
+        ],
+        [
+          Token('1', TokenType.VAL),
+          Token('1', TokenType.VAL),
+          Token('1', TokenType.VAL),
+          Token('^', TokenType.POW),
+          Token('^', TokenType.POW)
+        ]
+      )
+    };
+    parameterized(cases);
+  }
+
+  void tokenizeModulo() {
+    var cases = {
+      '1%1': (
+        [
+          Token('1', TokenType.VAL),
+          Token('%', TokenType.MOD),
+          Token('1', TokenType.VAL),
+        ],
+        [
+          Token('1', TokenType.VAL),
+          Token('1', TokenType.VAL),
+          Token('%', TokenType.MOD),
+        ]
+      ),
+    };
+    parameterized(cases);
+  }
+
+  void tokenizeMultiplication() {
+    var cases = {
+      '0 * 1': (
+        [
+          Token('0', TokenType.VAL),
+          Token('*', TokenType.TIMES),
+          Token('1', TokenType.VAL)
+        ],
+        [
+          Token('0', TokenType.VAL),
+          Token('1', TokenType.VAL),
+          Token('*', TokenType.TIMES)
+        ]
+      ),
+    };
+    parameterized(cases);
+  }
+
+  void tokenizeDivision() {
+    var cases = {
+      '0 / 1': (
+        [
+          Token('0', TokenType.VAL),
+          Token('/', TokenType.DIV),
+          Token('1', TokenType.VAL)
+        ],
+        [
+          Token('0', TokenType.VAL),
+          Token('1', TokenType.VAL),
+          Token('/', TokenType.DIV)
+        ]
+      ),
+    };
+    parameterized(cases);
+  }
+
+  void tokenizePlus() {
+    var cases = {
+      'x + 2': (
+        [
+          Token('x', TokenType.VAR),
+          Token('+', TokenType.PLUS),
+          Token('2', TokenType.VAL)
+        ],
+        [
+          Token('x', TokenType.VAR),
+          Token('2', TokenType.VAL),
+          Token('+', TokenType.PLUS)
+        ]
+      ),
+    };
+    parameterized(cases);
+  }
+
+  void tokenizeMinus() {
+    var cases = {
+      'x - 2': (
+        [
+          Token('x', TokenType.VAR),
+          Token('-', TokenType.MINUS),
+          Token('2', TokenType.VAL)
+        ],
+        [
+          Token('x', TokenType.VAR),
+          Token('2', TokenType.VAL),
+          Token('-', TokenType.MINUS)
+        ]
+      ),
+    };
+    parameterized(cases);
+  }
+
+  void tokenizeParenthesis() {
+    Map<String, (List<Token>, List<Token>)> cases = {
+      '()': ([Token('(', TokenType.LBRACE), Token(')', TokenType.RBRACE)], []),
+    };
+    parameterized(cases);
+  }
+
+  void tokenizeFunctions() {
+    var cases = {
+      'log(10,100)': (
+        [
+          Token('log', TokenType.LOG),
+          Token('(', TokenType.LBRACE),
+          Token('10', TokenType.VAL),
+          Token(',', TokenType.SEPAR),
+          Token('100', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [
+          Token('10', TokenType.VAL),
+          Token('100', TokenType.VAL),
+          Token('log', TokenType.LOG)
+        ]
+      ),
+      'ln(2)': (
+        [
+          Token('ln', TokenType.LN),
+          Token('(', TokenType.LBRACE),
+          Token('2', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('2', TokenType.VAL), Token('ln', TokenType.LN)]
+      ),
+      'sqrt(10)': (
+        [
+          Token('sqrt', TokenType.SQRT),
+          Token('(', TokenType.LBRACE),
+          Token('10', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('10', TokenType.VAL), Token('sqrt', TokenType.SQRT)]
+      ),
+      // n-th root
+      'nrt(2,10)': (
+        [
+          Token('nrt', TokenType.ROOT),
+          Token('(', TokenType.LBRACE),
+          Token('2', TokenType.VAL),
+          Token(',', TokenType.SEPAR),
+          Token('10', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [
+          Token('2', TokenType.VAL),
+          Token('10', TokenType.VAL),
+          Token('nrt', TokenType.ROOT)
+        ]
+      ),
+      'nrt(5,10-1)': (
+        [
+          Token('nrt', TokenType.ROOT),
+          Token('(', TokenType.LBRACE),
+          Token('5', TokenType.VAL),
+          Token(',', TokenType.SEPAR),
+          Token('10', TokenType.VAL),
+          Token('-', TokenType.MINUS),
+          Token('1', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [
+          Token('5', TokenType.VAL),
+          Token('10', TokenType.VAL),
+          Token('1', TokenType.VAL),
+          Token('-', TokenType.MINUS),
+          Token('nrt', TokenType.ROOT)
+        ]
+      ),
+      'cos(10)': (
+        [
+          Token('cos', TokenType.COS),
+          Token('(', TokenType.LBRACE),
+          Token('10', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('10', TokenType.VAL), Token('cos', TokenType.COS)]
+      ),
+      'sin(10)': (
+        [
+          Token('sin', TokenType.SIN),
+          Token('(', TokenType.LBRACE),
+          Token('10', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('10', TokenType.VAL), Token('sin', TokenType.SIN)]
+      ),
+      'tan(10)': (
+        [
+          Token('tan', TokenType.TAN),
+          Token('(', TokenType.LBRACE),
+          Token('10', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('10', TokenType.VAL), Token('tan', TokenType.TAN)]
+      ),
+      'arccos(1)': (
+        [
+          Token('arccos', TokenType.ACOS),
+          Token('(', TokenType.LBRACE),
+          Token('1', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('1', TokenType.VAL), Token('arccos', TokenType.ACOS)]
+      ),
+      'arcsin(1)': (
+        [
+          Token('arcsin', TokenType.ASIN),
+          Token('(', TokenType.LBRACE),
+          Token('1', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('1', TokenType.VAL), Token('arcsin', TokenType.ASIN)]
+      ),
+      'arctan(10)': (
+        [
+          Token('arctan', TokenType.ATAN),
+          Token('(', TokenType.LBRACE),
+          Token('10', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('10', TokenType.VAL), Token('arctan', TokenType.ATAN)]
+      ),
+      'abs(10)': (
+        [
+          Token('abs', TokenType.ABS),
+          Token('(', TokenType.LBRACE),
+          Token('10', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('10', TokenType.VAL), Token('abs', TokenType.ABS)]
+      ),
+      'sgn(10)': (
+        [
+          Token('sgn', TokenType.SGN),
+          Token('(', TokenType.LBRACE),
+          Token('10', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('10', TokenType.VAL), Token('sgn', TokenType.SGN)]
+      ),
+      // Exponential - function syntax
+      'e(x)': (
+        [
+          Token('e', TokenType.EFUNC),
+          Token('(', TokenType.LBRACE),
+          Token('x', TokenType.VAR),
+          Token(')', TokenType.RBRACE),
+        ],
+        [Token('x', TokenType.VAR), Token('e', TokenType.EFUNC)]
+      ),
+      // Exponential - power syntax
+      'e^x': (
+        [Token('e', TokenType.EFUNC), Token('x', TokenType.VAR)],
+        [Token('x', TokenType.VAR), Token('e', TokenType.EFUNC)]
+      ),
+      'e^(x+2)': (
+        [
+          Token('e', TokenType.EFUNC),
+          Token('(', TokenType.LBRACE),
+          Token('x', TokenType.VAR),
+          Token('+', TokenType.PLUS),
+          Token('2', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [
+          Token('x', TokenType.VAR),
+          Token('2', TokenType.VAL),
+          Token('+', TokenType.PLUS),
+          Token('e', TokenType.EFUNC)
+        ]
+      ),
+      'ceil(9.5)': (
+        [
+          Token('ceil', TokenType.CEIL),
+          Token('(', TokenType.LBRACE),
+          Token('9.5', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('9.5', TokenType.VAL), Token('ceil', TokenType.CEIL)]
+      ),
+      'floor(9.5)': (
+        [
+          Token('floor', TokenType.FLOOR),
+          Token('(', TokenType.LBRACE),
+          Token('9.5', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [Token('9.5', TokenType.VAL), Token('floor', TokenType.FLOOR)]
+      ),
+      '10!': (
+        [Token('10', TokenType.VAL), Token('!', TokenType.FACTORIAL)],
+        [Token('10', TokenType.VAL), Token('!', TokenType.FACTORIAL)]
+      ),
+    };
+    parameterized(cases);
+  }
+
+  void tokenizeAlgorithmicFunctions() {
+    var cases = {
+      'myAlgorithmicFunction(1.0)': (
+        [
+          Token('myAlgorithmicFunction', TokenType.FUNC),
+          Token('(', TokenType.LBRACE),
+          Token('1.0', TokenType.VAL),
+          Token(')', TokenType.RBRACE),
+        ],
+        [
+          Token('1.0', TokenType.VAL),
+          Token('myAlgorithmicFunction', TokenType.FUNC),
+        ]
+      ),
+      'my_min(1,x,-2)': (
+        [
+          Token('my_min', TokenType.FUNC),
+          Token('(', TokenType.LBRACE),
+          Token('1', TokenType.VAL),
+          Token(',', TokenType.SEPAR),
+          Token('x', TokenType.VAR),
+          Token(',', TokenType.SEPAR),
+          Token('-', TokenType.MINUS),
+          Token('2', TokenType.VAL),
+          Token(')', TokenType.RBRACE),
+        ],
+        [
+          Token('1', TokenType.VAL),
+          Token('x', TokenType.VAR),
+          Token('2', TokenType.VAL),
+          Token('-', TokenType.UNMINUS),
+          Token('my_min', TokenType.FUNC),
+        ]
+      ),
+    };
+
+    lex.keywords['myAlgorithmicFunction'] = TokenType.FUNC;
+    lex.keywords['my_min'] = TokenType.FUNC;
+
+    parameterized(cases);
+  }
+
+  void tokenizeComplexExpression() {
+    var cases = {
+      'x * 2^2.5 * log(10,100)': (
+        [
+          Token('x', TokenType.VAR),
+          Token('*', TokenType.TIMES),
+          Token('2', TokenType.VAL),
+          Token('^', TokenType.POW),
+          Token('2.5', TokenType.VAL),
+          Token('*', TokenType.TIMES),
+          Token('log', TokenType.LOG),
+          Token('(', TokenType.LBRACE),
+          Token('10', TokenType.VAL),
+          Token(',', TokenType.SEPAR),
+          Token('100', TokenType.VAL),
+          Token(')', TokenType.RBRACE)
+        ],
+        [
+          Token('x', TokenType.VAR),
+          Token('2', TokenType.VAL),
+          Token('2.5', TokenType.VAL),
+          Token('^', TokenType.POW),
+          Token('*', TokenType.TIMES),
+          Token('10', TokenType.VAL),
+          Token('100', TokenType.VAL),
+          Token('log', TokenType.LOG),
+          Token('*', TokenType.TIMES)
+        ]
+      ),
+    };
+    parameterized(cases);
+  }
+
+  void lexerTokenTestInvalid() {
+    Map<String, Matcher> invalidCases = {
+      '(': throwsFormatException,
+      ')': throwsFormatException,
+      '1+1)': throwsFormatException,
+      '(1+1': throwsFormatException,
+      'log(1,': throwsFormatException,
+    };
+
+    for (String expr in invalidCases.keys) {
+      test(expr,
+          () => expect(() => lex.tokenizeToRPN(expr), invalidCases[expr]));
+    }
+  }
+}

--- a/test/math_expressions_test.dart
+++ b/test/math_expressions_test.dart
@@ -10,6 +10,7 @@ import 'test_framework.dart';
 
 part 'algebra_test_set.dart';
 part 'expression_test_set.dart';
+part 'lexer_test_set.dart';
 part 'parser_test_set.dart';
 
 /// relative accuracy for floating-point calculations
@@ -19,6 +20,7 @@ const num EPS = 0.000001;
 void main() {
   final List<TestSet> testSets = <TestSet>[
     AlgebraTests(),
+    LexerTests(),
     ParserTests(),
     ExpressionTests()
   ];

--- a/test/parser_test_set.dart
+++ b/test/parser_test_set.dart
@@ -1,6 +1,6 @@
 part of 'math_expressions_test.dart';
 
-/// Contains a test set for testing the parser and lexer
+/// Contains a test set for testing the parser
 class ParserTests extends TestSet {
   @override
   String get name => 'Parser Tests';
@@ -10,496 +10,285 @@ class ParserTests extends TestSet {
 
   @override
   Map<String, Function> get testFunctions => {
-        'Lexer Tokenize (Infix + Postfix)': lexerTokenTest,
-        'Lexer Tokenize Invalid': lexerTokenTestInvalid,
-        'Parser Expression Creation': parserExpressionTest,
-        'Parser Expression Creation Invalid': parserExpressionTestInvalid,
-        'Parser Expression Creation from toString()':
-            parserExpressionTest_ParseFromToString,
-        'Parser Operator Precedence': parserOperatorPrecedence,
+        // TODO: Refactor these to be included in the individual test groups
+        'Parse from toString())': parseFromToString,
       };
 
   @override
-  void initTests() {
-    pars = Parser();
-    lex = Lexer();
+  Map<String, Function> get testGroups => {
+        // Literals
+        'Number': parseNumber,
+        'Variable': parseVariable,
+        'Parenthesis': parseParenthesis,
 
-    inputStrings = [];
-    tokenStreams = [];
-    rpnTokenStreams = [];
+        // Operators
+        'Unary Minus': parseUnaryMinus,
+        'Unary Plus': parseUnaryPlus,
+        'Power': parsePower,
+        'Modulo': parseModulo,
+        'Multiplication': parseMultiplication,
+        'Division': parseDivision,
+        'Addition': parsePlus,
+        'Subtraction': parseMinus,
+        'Operator Precedence': parseOperatorPrecedence,
 
-    /*
-     *  Operations
-     */
-    // Plus
-    inputStrings.add('x + 2');
-    tokenStreams.add([
-      Token('x', TokenType.VAR),
-      Token('+', TokenType.PLUS),
-      Token('2', TokenType.VAL)
-    ]);
-    rpnTokenStreams.add([
-      Token('x', TokenType.VAR),
-      Token('2', TokenType.VAL),
-      Token('+', TokenType.PLUS)
-    ]);
+        // Functions
+        'Functions': parseFunctions,
+        //'Custom functions': parseCustomFunctions,
+        'Algorithmic functions': parseAlgorithmicFunctions,
 
-    // Minus
-    inputStrings.add('x - 2');
-    tokenStreams.add([
-      Token('x', TokenType.VAR),
-      Token('-', TokenType.MINUS),
-      Token('2', TokenType.VAL)
-    ]);
-    rpnTokenStreams.add([
-      Token('x', TokenType.VAR),
-      Token('2', TokenType.VAL),
-      Token('-', TokenType.MINUS)
-    ]);
+        // Expressions
+        'Complex expression': parseComplexExpression,
 
-    inputStrings.add('0 - 1');
-    tokenStreams.add([
-      Token('0', TokenType.VAL),
-      Token('-', TokenType.MINUS),
-      Token('1', TokenType.VAL)
-    ]);
-    rpnTokenStreams.add([
-      Token('0', TokenType.VAL),
-      Token('1', TokenType.VAL),
-      Token('-', TokenType.MINUS)
-    ]);
+        // Negative test cases
+        'Invalid': parserExpressionTestInvalid,
+      };
 
-    inputStrings.add('(0 - 1)');
-    tokenStreams.add([
-      Token('(', TokenType.LBRACE),
-      Token('0', TokenType.VAL),
-      Token('-', TokenType.MINUS),
-      Token('1', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams.add([
-      Token('0', TokenType.VAL),
-      Token('1', TokenType.VAL),
-      Token('-', TokenType.MINUS)
-    ]);
+  @override
+  void initTests() {}
 
-    // Multiplication
-    inputStrings.add('0 * 1');
-    tokenStreams.add([
-      Token('0', TokenType.VAL),
-      Token('*', TokenType.TIMES),
-      Token('1', TokenType.VAL)
-    ]);
-    rpnTokenStreams.add([
-      Token('0', TokenType.VAL),
-      Token('1', TokenType.VAL),
-      Token('*', TokenType.TIMES)
-    ]);
+  Parser parser = Parser();
 
-    // Division
-    inputStrings.add('0 / 1');
-    tokenStreams.add([
-      Token('0', TokenType.VAL),
-      Token('/', TokenType.DIV),
-      Token('1', TokenType.VAL)
-    ]);
-    rpnTokenStreams.add([
-      Token('0', TokenType.VAL),
-      Token('1', TokenType.VAL),
-      Token('/', TokenType.DIV)
-    ]);
-
-    // standard syntax
-    inputStrings.add('-1');
-    tokenStreams.add([Token('-', TokenType.MINUS), Token('1', TokenType.VAL)]);
-    rpnTokenStreams
-        .add([Token('1', TokenType.VAL), Token('-', TokenType.UNMINUS)]);
-
-    inputStrings.add('(-1)');
-    tokenStreams.add([
-      Token('(', TokenType.LBRACE),
-      Token('-', TokenType.MINUS),
-      Token('1', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('1', TokenType.VAL), Token('-', TokenType.UNMINUS)]);
-
-    inputStrings.add('-(1)');
-    tokenStreams.add([
-      Token('-', TokenType.MINUS),
-      Token('(', TokenType.LBRACE),
-      Token('1', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('1', TokenType.VAL), Token('-', TokenType.UNMINUS)]);
-
-    // unary plus
-    inputStrings.add('+1');
-    tokenStreams.add([Token('+', TokenType.PLUS), Token('1', TokenType.VAL)]);
-    rpnTokenStreams
-        .add([Token('1', TokenType.VAL), Token('+', TokenType.UNPLUS)]);
-
-    inputStrings.add('(+1)');
-    tokenStreams.add([
-      Token('(', TokenType.LBRACE),
-      Token('+', TokenType.PLUS),
-      Token('1', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('1', TokenType.VAL), Token('+', TokenType.UNPLUS)]);
-
-    inputStrings.add('+(1)');
-    tokenStreams.add([
-      Token('+', TokenType.PLUS),
-      Token('(', TokenType.LBRACE),
-      Token('1', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('1', TokenType.VAL), Token('+', TokenType.UNPLUS)]);
-
-    // Power
-    inputStrings.add('1^1^1');
-    tokenStreams.add([
-      Token('1', TokenType.VAL),
-      Token('^', TokenType.POW),
-      Token('1', TokenType.VAL),
-      Token('^', TokenType.POW),
-      Token('1', TokenType.VAL)
-    ]);
-    rpnTokenStreams.add([
-      Token('1', TokenType.VAL),
-      Token('1', TokenType.VAL),
-      Token('1', TokenType.VAL),
-      Token('^', TokenType.POW),
-      Token('^', TokenType.POW)
-    ]);
-
-    /*
-     *  Functions
-     */
-    // Log
-    inputStrings.add('log(10,100)');
-    tokenStreams.add([
-      Token('log', TokenType.LOG),
-      Token('(', TokenType.LBRACE),
-      Token('10', TokenType.VAL),
-      Token(',', TokenType.SEPAR),
-      Token('100', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams.add([
-      Token('10', TokenType.VAL),
-      Token('100', TokenType.VAL),
-      Token('log', TokenType.LOG)
-    ]);
-
-    // Ln
-    inputStrings.add('ln(10)');
-    tokenStreams.add([
-      Token('ln', TokenType.LN),
-      Token('(', TokenType.LBRACE),
-      Token('10', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('10', TokenType.VAL), Token('ln', TokenType.LN)]);
-
-    // Sqrt
-    inputStrings.add('sqrt(10)');
-    tokenStreams.add([
-      Token('sqrt', TokenType.SQRT),
-      Token('(', TokenType.LBRACE),
-      Token('10', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('10', TokenType.VAL), Token('sqrt', TokenType.SQRT)]);
-
-    // Cos
-    inputStrings.add('cos(10)');
-    tokenStreams.add([
-      Token('cos', TokenType.COS),
-      Token('(', TokenType.LBRACE),
-      Token('10', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('10', TokenType.VAL), Token('cos', TokenType.COS)]);
-
-    // Sin
-    inputStrings.add('sin(10)');
-    tokenStreams.add([
-      Token('sin', TokenType.SIN),
-      Token('(', TokenType.LBRACE),
-      Token('10', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('10', TokenType.VAL), Token('sin', TokenType.SIN)]);
-
-    // Tan
-    inputStrings.add('tan(10)');
-    tokenStreams.add([
-      Token('tan', TokenType.TAN),
-      Token('(', TokenType.LBRACE),
-      Token('10', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('10', TokenType.VAL), Token('tan', TokenType.TAN)]);
-
-    // Arccos
-    inputStrings.add('arccos(1)');
-    tokenStreams.add([
-      Token('arccos', TokenType.ACOS),
-      Token('(', TokenType.LBRACE),
-      Token('1', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('1', TokenType.VAL), Token('arccos', TokenType.ACOS)]);
-
-    // Arcsin
-    inputStrings.add('arcsin(1)');
-    tokenStreams.add([
-      Token('arcsin', TokenType.ASIN),
-      Token('(', TokenType.LBRACE),
-      Token('1', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('1', TokenType.VAL), Token('arcsin', TokenType.ASIN)]);
-
-    // Arctan
-    inputStrings.add('arctan(10)');
-    tokenStreams.add([
-      Token('arctan', TokenType.ATAN),
-      Token('(', TokenType.LBRACE),
-      Token('10', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('10', TokenType.VAL), Token('arctan', TokenType.ATAN)]);
-
-    // Abs
-    inputStrings.add('abs(10)');
-    tokenStreams.add([
-      Token('abs', TokenType.ABS),
-      Token('(', TokenType.LBRACE),
-      Token('10', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('10', TokenType.VAL), Token('abs', TokenType.ABS)]);
-    // Sgn
-    inputStrings.add('sgn(10)');
-    tokenStreams.add([
-      Token('sgn', TokenType.SGN),
-      Token('(', TokenType.LBRACE),
-      Token('10', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('10', TokenType.VAL), Token('sgn', TokenType.SGN)]);
-
-    // n-th root
-    inputStrings.add('nrt(2,10)');
-    tokenStreams.add([
-      Token('nrt', TokenType.ROOT),
-      Token('(', TokenType.LBRACE),
-      Token('2', TokenType.VAL),
-      Token(',', TokenType.SEPAR),
-      Token('10', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams.add([
-      Token('2', TokenType.VAL),
-      Token('10', TokenType.VAL),
-      Token('nrt', TokenType.ROOT)
-    ]);
-
-    // ceil
-    inputStrings.add('ceil(1.2)');
-    tokenStreams.add([
-      Token('ceil', TokenType.CEIL),
-      Token('(', TokenType.LBRACE),
-      Token('1.2', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('1.2', TokenType.VAL), Token('ceil', TokenType.CEIL)]);
-
-    // floor
-    inputStrings.add('floor(1.2)');
-    tokenStreams.add([
-      Token('floor', TokenType.FLOOR),
-      Token('(', TokenType.LBRACE),
-      Token('1.2', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams
-        .add([Token('1.2', TokenType.VAL), Token('floor', TokenType.FLOOR)]);
-
-    inputStrings.add('nrt(5,10-1)');
-    tokenStreams.add([
-      Token('nrt', TokenType.ROOT),
-      Token('(', TokenType.LBRACE),
-      Token('5', TokenType.VAL),
-      Token(',', TokenType.SEPAR),
-      Token('10', TokenType.VAL),
-      Token('-', TokenType.MINUS),
-      Token('1', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams.add([
-      Token('5', TokenType.VAL),
-      Token('10', TokenType.VAL),
-      Token('1', TokenType.VAL),
-      Token('-', TokenType.MINUS),
-      Token('nrt', TokenType.ROOT)
-    ]);
-
-    // Factorial
-    inputStrings.add('10!');
-    tokenStreams
-        .add([Token('10', TokenType.VAL), Token('!', TokenType.FACTORIAL)]);
-    rpnTokenStreams
-        .add([Token('10', TokenType.VAL), Token('!', TokenType.FACTORIAL)]);
-
-    // Exp
-    // function syntax
-    inputStrings.add('e(x)');
-    tokenStreams.add([
-      Token('e', TokenType.EFUNC),
-      Token('(', TokenType.LBRACE),
-      Token('x', TokenType.VAR),
-      Token(')', TokenType.RBRACE),
-    ]);
-    rpnTokenStreams
-        .add([Token('x', TokenType.VAR), Token('e', TokenType.EFUNC)]);
-
-    // power syntax
-    inputStrings.add('e^x');
-    tokenStreams.add([Token('e', TokenType.EFUNC), Token('x', TokenType.VAR)]);
-    rpnTokenStreams
-        .add([Token('x', TokenType.VAR), Token('e', TokenType.EFUNC)]);
-
-    inputStrings.add('e^(x+2)');
-    tokenStreams.add([
-      Token('e', TokenType.EFUNC),
-      Token('(', TokenType.LBRACE),
-      Token('x', TokenType.VAR),
-      Token('+', TokenType.PLUS),
-      Token('2', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams.add([
-      Token('x', TokenType.VAR),
-      Token('2', TokenType.VAL),
-      Token('+', TokenType.PLUS),
-      Token('e', TokenType.EFUNC)
-    ]);
-
-    // Algorithmic function
-    pars.addFunction('my_min', (List<double> args) => args.reduce(math.min));
-    lex.keywords['my_min'] = TokenType.FUNC;
-    inputStrings.add('my_min(1,x,-2)');
-    tokenStreams.add([
-      Token('my_min', TokenType.FUNC),
-      Token('(', TokenType.LBRACE),
-      Token('1', TokenType.VAL),
-      Token(',', TokenType.SEPAR),
-      Token('x', TokenType.VAR),
-      Token(',', TokenType.SEPAR),
-      Token('-', TokenType.MINUS),
-      Token('2', TokenType.VAL),
-      Token(')', TokenType.RBRACE),
-    ]);
-    rpnTokenStreams.add([
-      Token('1', TokenType.VAL),
-      Token('x', TokenType.VAR),
-      Token('2', TokenType.VAL),
-      Token('-', TokenType.UNMINUS),
-      Token('my_min', TokenType.FUNC),
-    ]);
-
-    // Complex expressions
-    inputStrings.add('x * 2^2.5 * log(10,100)');
-    tokenStreams.add([
-      Token('x', TokenType.VAR),
-      Token('*', TokenType.TIMES),
-      Token('2', TokenType.VAL),
-      Token('^', TokenType.POW),
-      Token('2.5', TokenType.VAL),
-      Token('*', TokenType.TIMES),
-      Token('log', TokenType.LOG),
-      Token('(', TokenType.LBRACE),
-      Token('10', TokenType.VAL),
-      Token(',', TokenType.SEPAR),
-      Token('100', TokenType.VAL),
-      Token(')', TokenType.RBRACE)
-    ]);
-    rpnTokenStreams.add([
-      Token('x', TokenType.VAR),
-      Token('2', TokenType.VAL),
-      Token('2.5', TokenType.VAL),
-      Token('^', TokenType.POW),
-      Token('*', TokenType.TIMES),
-      Token('10', TokenType.VAL),
-      Token('100', TokenType.VAL),
-      Token('log', TokenType.LOG),
-      Token('*', TokenType.TIMES)
-    ]);
+  void parameterized(Map<String, Expression> cases) {
+    cases.forEach((key, value) {
+      test('$key -> $value',
+          () => expect(parser.parse(key).toString(), value.toString()));
+    });
   }
 
-  /*
-   *  Tests and variables.
-   */
-  late Parser pars;
-  late Lexer lex;
-  late List<String> inputStrings;
-
-  late List<List<Token>> tokenStreams;
-  late List<List<Token>> rpnTokenStreams;
-
-  void lexerTokenTest() {
-    for (int i = 0; i < inputStrings.length; i++) {
-      String input = inputStrings[i];
-
-      // Test infix streams
-      List<Token> infixStream = lex.tokenize(input);
-      expect(infixStream, orderedEquals(tokenStreams[i]));
-
-      // Test RPN streams
-      List<Token> rpnStream = lex.shuntingYard(infixStream);
-      expect(rpnStream, orderedEquals(rpnTokenStreams[i]));
-    }
+  void parseNumber() {
+    var cases = {
+      '0': Number(0),
+      '1': Number(1),
+      '1.0': Number(1.0),
+      math.pi.toStringAsFixed(11): Number(3.14159265359),
+      '0.0': Number(0.0),
+      // max precision 15 digits
+      '999999999999999': Number(999999999999999),
+    };
+    parameterized(cases);
   }
 
-  void lexerTokenTestInvalid() {
-    Map<String, Matcher> invalidCases = {
-      '(': throwsFormatException,
-      ')': throwsFormatException,
-      '1+1)': throwsFormatException,
-      '(1+1': throwsFormatException,
-      'log(1,': throwsFormatException,
+  void parseVariable() {
+    var cases = {
+      'x': Variable('x'),
+      ' x': Variable('x'),
+      '(y )': Variable('y'),
+      //'var2': Variable('var2'), // Does not support numbers in variable names
+      'longname': Variable('longname'),
+    };
+    parameterized(cases);
+  }
+
+  void parseUnaryMinus() {
+    var cases = {
+      '-0': -Number(0),
+      '-1': -Number(1),
+      '-1.0': -Number(1.0),
+    };
+    parameterized(cases);
+  }
+
+  void parseUnaryPlus() {
+    var cases = {
+      '+0': UnaryPlus(Number(0)),
+      '+1': UnaryPlus(Number(1)),
+      '+1.0': UnaryPlus(Number(1.0)),
+    };
+    parameterized(cases);
+  }
+
+  void parsePower() {
+    var cases = {
+      '1^1': Number(1) ^ Number(1),
+      '1^0': Number(1) ^ Number(0),
+      '(-1) ^ 2': -Number(1) ^ Number(2),
+      '-1^2': -(Number(1) ^ Number(2)),
+      '1^0 ^20': Number(1) ^ (Number(0) ^ Number(20)),
+    };
+    parameterized(cases);
+  }
+
+  void parseModulo() {
+    var cases = {
+      '1%1': Number(1) % Number(1),
+      '100.0 % 20': Number(100.0) % Number(20),
+    };
+    parameterized(cases);
+  }
+
+  void parseMultiplication() {
+    var cases = {
+      '0 * 1': Number(0) * Number(1),
+      '-2.0 * 5': -Number(2.0) * Number(5),
+    };
+    parameterized(cases);
+  }
+
+  void parseDivision() {
+    var cases = {
+      '0 / 1': Number(0) / Number(1),
+      '-2.0 / 5': -Number(2.0) / Number(5),
+    };
+    parameterized(cases);
+  }
+
+  void parsePlus() {
+    var cases = {
+      'x + 2': Variable('x') + Number(2),
+    };
+    parameterized(cases);
+  }
+
+  void parseMinus() {
+    var cases = {
+      'x - 2': Variable('x') - Number(2),
+      '0 - 2': Number(0) - Number(2),
+    };
+    parameterized(cases);
+  }
+
+  void parseOperatorPrecedence() {
+    var cases = {
+      '-3^2': UnaryMinus(Number(3.0) ^ Number(2.0)),
+      '-3*2': UnaryMinus(Number(3.0)) * Number(2.0),
+    };
+    parameterized(cases);
+  }
+
+  void parseParenthesis() {
+    var cases = {
+      '(0)': Number(0),
+      '(0-x)': Number(0) - Variable('x'),
+    };
+    parameterized(cases);
+  }
+
+  void parseFunctions() {
+    var cases = {
+      'log(10,100)': Log(Number(10), Number(100)),
+      'ln(2)': Ln(Number(2)),
+      'sqrt(10)': Sqrt(Number(10)),
+      // n-th root
+      'nrt(2,10)': Root(2, Number(10)),
+      'nrt(5,10-1)': Root(5, Number(10) - Number(1)),
+      'cos(10)': Cos(Number(10)),
+      'sin(10)': Sin(Number(10)),
+      'tan(10)': Tan(Number(10)),
+      'arccos(1)': Acos(Number(1)),
+      'arcsin(1)': Asin(Number(1)),
+      'arctan(10)': Atan(Number(10)),
+      'abs(10)': Abs(Number(10)),
+      'sgn(10)': Sgn(Number(10)),
+      // Exponential - function syntax
+      'e(x)': Exponential(Variable('x')),
+      // Exponential - power syntax
+      'e^x': Exponential(Variable('x')),
+      'e^(x+2)': Exponential(Variable('x') + Number(2)),
+      'ceil(9.5)': Ceil(Number(9.5)),
+      'floor(9.5)': Floor(Number(9.5)),
+      '10!': Factorial(Number(10)),
+    };
+    parameterized(cases);
+  }
+
+  void parseCustomFunctions() {
+    var cases = {
+      'myCustomFunction(x)':
+          CustomFunction('myCustomFunction', [Variable('x')], Number(0)),
+    };
+    parameterized(cases);
+  }
+
+  void parseAlgorithmicFunctions() {
+    var cases = {
+      'myAlgorithmicFunction(1.0)': AlgorithmicFunction(
+          'myAlgorithmicFunction', [Number(1.0)], () => null),
+      'my_min(1,x,-2)': AlgorithmicFunction('my_min',
+          [Number(1), Variable('x'), UnaryMinus(Number(2))], () => null),
     };
 
-    for (String expr in invalidCases.keys) {
-      expect(() => lex.tokenizeToRPN(expr), invalidCases[expr]);
+    if (!parser.functionHandlers.containsKey('myAlgorithmicFunction')) {
+      parser.addFunction('myAlgorithmicFunction', () => null);
     }
+
+    if (!parser.functionHandlers.containsKey('my_min')) {
+      parser.addFunction(
+          'my_min', (List<double> args) => args.reduce(math.min));
+    }
+
+    parameterized(cases);
   }
 
-  void parserExpressionTest() {
-    for (String inputString in inputStrings) {
-      Expression exp = pars.parse(inputString);
-      // TODO Don't just test for no exceptions,
-      // also test for expression content.
-      expect(exp, isNotNull);
+  void parseComplexExpression() {
+    var cases = {
+      'x * 2^2.5 * log(10,100)': Variable('x') *
+          Power(Number(2), Number(2.5)) *
+          Log(Number(10), Number(100))
+    };
+    parameterized(cases);
+  }
+
+  void parseFromToString() {
+    const expressions = [
+      'x + 2',
+      'x - 2',
+      '0 - 1',
+      '(0 - 1)',
+      '0 * 1',
+      '0 / 1',
+      '-1',
+      '(-1)',
+      '-(1)',
+      '+1',
+      '(+1)',
+      '+(1)',
+      '1^1^1',
+      'log(10,100)',
+      'ln(10)',
+      'sqrt(10)',
+      'cos(10)',
+      'sin(10)',
+      'tan(10)',
+      'arccos(1)',
+      'arcsin(1)',
+      'arctan(10)',
+      'abs(10)',
+      'sgn(10)',
+      'nrt(2,10)',
+      'nrt(5,10-1)',
+      'ceil(1.2)',
+      'floor(1.2)',
+      '10!',
+      'e(x)',
+      'e^x',
+      'e^(x+2)',
+      'my_min(1,x,-2)',
+      'x * 2^2.5 * log(10,100)',
+    ];
+
+    ContextModel context = ContextModel()
+      ..bindVariableName('x', Number(math.pi));
+
+    for (String expression in expressions) {
+      /// Expression doesn't implement equal, so as an approximation
+      /// we're testing whether the expression re-parses and evaluates
+      /// to the same value.
+      Expression exp = parser.parse(expression);
+
+      try {
+        Expression exp2 = parser.parse(exp.toString());
+
+        double r1 = exp.evaluate(EvaluationType.REAL, context);
+        double r2 = exp2.evaluate(EvaluationType.REAL, context);
+        expect(r2, r1, reason: 'Expected $r2 for $exp ($exp2)');
+      } on FormatException catch (fe) {
+        expect(fe, isNot(isFormatException),
+            reason: 'Expected no exception for $expression ($exp)');
+      } on RangeError catch (re) {
+        expect(re, isNot(isRangeError),
+            reason: 'Expected no exception for $expression ($exp)');
+      }
     }
   }
 
@@ -515,41 +304,7 @@ class ParserTests extends TestSet {
     };
 
     for (String expr in invalidCases.keys) {
-      expect(() => pars.parse(expr), invalidCases[expr]);
+      test(expr, () => expect(() => parser.parse(expr), invalidCases[expr]));
     }
-  }
-
-  void parserExpressionTest_ParseFromToString() {
-    ContextModel context = ContextModel()
-      ..bindVariableName('x', Number(math.pi));
-
-    for (String inputString in inputStrings) {
-      /// Expression doesn't implement equal, so as an approximation
-      /// we're testing whether the expression re-parses and evaluates
-      /// to the same value.
-      Expression exp = pars.parse(inputString);
-
-      try {
-        Expression exp2 = pars.parse(exp.toString());
-
-        double r1 = exp.evaluate(EvaluationType.REAL, context);
-        double r2 = exp2.evaluate(EvaluationType.REAL, context);
-        expect(r2, r1, reason: 'Expected $r2 for $exp ($exp2)');
-      } on FormatException catch (fe) {
-        expect(fe, isNot(isFormatException),
-            reason: 'Expected no exception for $inputString ($exp)');
-      } on RangeError catch (re) {
-        expect(re, isNot(isRangeError),
-            reason: 'Expected no exception for $inputString ($exp)');
-      }
-    }
-  }
-
-  void parserOperatorPrecedence() {
-    Expression e = pars.parse('-3^2');
-    expect(e.toString(), equals('(-(3.0^2.0))'));
-
-    e = pars.parse('-3*2');
-    expect(e.toString(), equals('((-3.0) * 2.0)'));
   }
 }

--- a/test/parser_test_set.dart
+++ b/test/parser_test_set.dart
@@ -6,6 +6,9 @@ class ParserTests extends TestSet {
   String get name => 'Parser Tests';
 
   @override
+  String get tags => 'parser';
+
+  @override
   Map<String, Function> get testFunctions => {
         'Lexer Tokenize (Infix + Postfix)': lexerTokenTest,
         'Lexer Tokenize Invalid': lexerTokenTestInvalid,

--- a/test/test_framework.dart
+++ b/test/test_framework.dart
@@ -32,7 +32,10 @@ class TestExecutor {
       group(set.name, () {
         setUp(set.initTests);
         set.testFunctions.forEach((String k, Function v) {
-          test(k, () => v());
+          test(k, () => v(), tags: set.tags);
+        });
+        set.testGroups.forEach((String k, Function v) {
+          group(k, () => v(), tags: set.tags);
         });
       });
     }
@@ -49,9 +52,15 @@ abstract class TestSet {
   /// Returns the designated name of this test set.
   String get name;
 
+  /// Returns the tags to be attached to this test set.
+  String? get tags => null;
+
   /// Initializes any requirements for the tests to run.
   void initTests();
 
   /// Returns a map containing test function names and associated function calls.
-  Map<String, Function> get testFunctions;
+  Map<String, Function> get testFunctions => {};
+
+  /// Returns a map containing test group names and associated function calls.
+  Map<String, Function> get testGroups => {};
 }


### PR DESCRIPTION
- Tests: Split lexer and parser test suites
- Test framework: Support tags and groups
- Drop support for Dart SDK below 3.0.0
- Lint: `use_super_parameters`