### PR TITLE
Parser: Add options to configure parser behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.5.1] - 2024-05-23
+## [unreleased] - 2024-05-23
 
 ### Added
 
-- Add support for multiplying parentheses
+- Add parser support for implicit multiplication (thanks [juca1331](https://github.com/juca1331))
 
 ## [2.5.0] - 2024-04-16
 

--- a/test/parser_test_set.dart
+++ b/test/parser_test_set.dart
@@ -27,7 +27,7 @@ class ParserTests extends TestSet {
         'Power': parsePower,
         'Modulo': parseModulo,
         'Multiplication': parseMultiplication,
-        'MultiplicationWithParentheses': parseMultiplicationWithParentheses,
+        'ImplicitMultiplication': parseImplicitMultiplication,
         'Division': parseDivision,
         'Addition': parsePlus,
         'Subtraction': parseMinus,
@@ -50,16 +50,15 @@ class ParserTests extends TestSet {
 
   Parser parser = Parser();
 
-  void parameterized(Map<String, Expression> cases,
-      {bool multiplyWithParentheses = false}) {
+  void parameterized(Map<String, Expression> cases, {Parser? parser}) {
+    parser ??= this.parser;
     cases.forEach((key, value) {
       test(
           '$key -> $value',
           () => expect(
-              parser
+              parser!
                   .parse(
                     key,
-                    multiplyWithParentheses: multiplyWithParentheses,
                   )
                   .toString(),
               value.toString()));
@@ -137,12 +136,13 @@ class ParserTests extends TestSet {
     parameterized(cases);
   }
 
-  void parseMultiplicationWithParentheses() {
+  void parseImplicitMultiplication() {
     var cases = {
       '(5)(5)': Number(5) * Number(5),
       '(-2.0)5': -Number(2.0) * Number(5),
     };
-    parameterized(cases, multiplyWithParentheses: true);
+    var parser = Parser(ParserOptions(implicitMultiplication: true));
+    parameterized(cases, parser: parser);
   }
 
   void parseDivision() {


### PR DESCRIPTION
Follow-up from #87:

Move `multiplyWithParentheses` flag into options and rename to `implicitMultiplication`.

Add lexer tests for implicit multiplication.