### PR TITLE
feat: support implicit multiplication in grammar parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+
+- Add support for implicit multiplication to `GrammarParser`.
+
 ## [3.1.0] - 2025-06-29
 
 ### Changed
@@ -107,7 +113,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Renamed the existing expression parser to `ShuntingYardParser`. This parser
   is now in maintenance mode and will not receive any new features.
-  `Parser` remains as a deprecated type alias to this legacy implemenation to
+  `Parser` remains as a deprecated type alias to this legacy implementation to
   maintain backwards compatibility.
 
 ### Fixed

--- a/test/parser_petit_test_set.dart
+++ b/test/parser_petit_test_set.dart
@@ -32,7 +32,7 @@ class PetitParserTests extends TestSet {
     'Power': parsePower,
     'Modulo': parseModulo,
     'Multiplication': parseMultiplication,
-    //'ImplicitMultiplication': parseImplicitMultiplication,
+    'ImplicitMultiplication': parseImplicitMultiplication,
     'Division': parseDivision,
     'Addition': parsePlus,
     'Subtraction': parseMinus,
@@ -184,8 +184,11 @@ class PetitParserTests extends TestSet {
 
   void parseImplicitMultiplication() {
     var cases = {
+      '2x': Number(2) * Variable('x'),
       '(5)(5)': Number(5) * Number(5),
       '(-2.0)5': -Number(2.0) * Number(5),
+      '2(x+1)': Number(2) * (Variable('x') + Number(1)),
+      '(x+1)(x-1)': (Variable('x') + Number(1)) * (Variable('x') - Number(1)),
     };
 
     var parser = GrammarParser(ParserOptions(implicitMultiplication: true));


### PR DESCRIPTION
This feature was supported in the old parser but not ported to the new one yet.